### PR TITLE
fix/input-icon-styles

### DIFF
--- a/src/Input/InputWithIcon.js
+++ b/src/Input/InputWithIcon.js
@@ -9,6 +9,7 @@ const InputWithIcon = ({
   iconPosition,
   className,
   inputClassName,
+  iconClassName,
   ...props
 }) => {
   return (
@@ -20,7 +21,7 @@ const InputWithIcon = ({
       {iconPosition && (
         <Icon
           type={icon}
-          className={`${styles.icon} ${styles[iconPosition]}`}
+          className={`${iconClassName} ${styles.icon} ${styles[iconPosition]}`}
         />
       )}
     </div>
@@ -31,13 +32,15 @@ InputWithIcon.propTypes = {
   icon: PropTypes.string.isRequired,
   iconPosition: PropTypes.oneOf(['left', 'right']),
   className: PropTypes.string,
-  inputClassName: PropTypes.string
+  inputClassName: PropTypes.string,
+  iconClassName: PropTypes.string
 }
 
 InputWithIcon.defaultProps = {
   iconPosition: undefined,
   className: '',
-  inputClassName: ''
+  inputClassName: '',
+  iconClassName: ''
 }
 
 export default InputWithIcon

--- a/src/Input/InputWithIcon.module.scss
+++ b/src/Input/InputWithIcon.module.scss
@@ -9,6 +9,8 @@
 }
 
 .icon {
+    box-sizing: content-box;
+    width: 14px;
     position: absolute;
     top: 0;
     padding: 0 10px;

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import { InputWithIcon } from '../Input'
+import styles from './Search.module.scss'
 
 const Search = props => {
   return (
     <InputWithIcon
       icon='search-small'
+      iconClassName={styles.icon}
       placeholder='Type to search...'
       {...props}
     />

--- a/src/Search/Search.module.scss
+++ b/src/Search/Search.module.scss
@@ -1,0 +1,3 @@
+.icon {
+    width: 12px;
+}


### PR DESCRIPTION
#### Summary
Specifying icon `width` and `box-sizing` by default.
`InputWithIcon` `iconClassName` prop.