### PR TITLE
enhance/selector

### DIFF
--- a/src/Selector/Selector.js
+++ b/src/Selector/Selector.js
@@ -44,7 +44,6 @@ export class Selector extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    console.log(prevProps, this.props)
     if (this.props.defaultSelected !== prevProps.defaultSelected) {
       this.setState({ topic: this.props.defaultSelected })
     }

--- a/src/Selector/Selector.js
+++ b/src/Selector/Selector.js
@@ -43,13 +43,20 @@ export class Selector extends Component {
     variant: PropTypes.oneOf(['border'])
   }
 
+  componentDidUpdate (prevProps) {
+    console.log(prevProps, this.props)
+    if (this.props.defaultSelected !== prevProps.defaultSelected) {
+      this.setState({ topic: this.props.defaultSelected })
+    }
+  }
+
   onSelectOption = newOption => {
     this.setState({ selected: newOption }, () => {
       this.props.onSelectOption(newOption)
     })
   }
 
-  render() {
+  render () {
     const { selected } = this.state
     const {
       variant,


### PR DESCRIPTION
**Summary**
added ability to change active tab if `defaultSelected` value was changed.
It's for bug on `trendsExplorePage` (for mobile it can be used frequently) when you toggle that and use `history.back`
everything is updating, but active selector tab - no

**Video**
![in action](https://media.giphy.com/media/hQQskHZNccjwxAHKv1/giphy.gif)