### PR TITLE
fix: title of notifications

### DIFF
--- a/src/Notification/Notification.module.scss
+++ b/src/Notification/Notification.module.scss
@@ -43,7 +43,7 @@
 
 .title {
   font-weight: bold;
-  padding: 0 30px 0 15px;
+  padding: 0 30px 0 11px;
   width: 100%;
   color: var(--black);
 }


### PR DESCRIPTION
Summary:
* fixed padding of notification's title

Screenshots:
BEFORE:
![image](https://user-images.githubusercontent.com/14061779/63924701-665c5680-ca51-11e9-939d-8ee533d8d103.png)
AFTER:
![image](https://user-images.githubusercontent.com/14061779/63924733-72481880-ca51-11e9-9483-0469d9625375.png)
