### PR TITLE
Feature/suggestions with groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "PORT=3000 node server/index.js",
     "clean": "rimraf lib-build",
     "test:js": "jest",
-    "test": "yarn test:js",
+    "test": "NODE_ENV=test && yarn test:js",
     "scripts": "node scripts/copy-files && node scripts/update-version",
     "lib-publish": "yarn publish lib-build --patch --no-git-tag-version",
     "build:storybook": "build-storybook -o build",

--- a/src/Search/SearchWithSuggestions/NoResults.js
+++ b/src/Search/SearchWithSuggestions/NoResults.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import styles from './NoResults.module.scss'
+import commonStyles from './SuggestionItem.module.scss'
+
+const NoResults = ({ isSearching }) => (
+  <div className={commonStyles.suggestion + ' ' + styles.noresults}>
+    {!isSearching ? 'No results found' : 'Searching...'}
+  </div>
+)
+
+export default NoResults

--- a/src/Search/SearchWithSuggestions/NoResults.module.scss
+++ b/src/Search/SearchWithSuggestions/NoResults.module.scss
@@ -1,0 +1,14 @@
+@import '../../mixins';
+
+.noresults {
+  @include text-normal;
+
+  cursor: initial;
+  min-height: auto;
+  text-align: center;
+
+  &:hover,
+  &:focus {
+    background-color: inherit !important;
+  }
+}

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
@@ -16,17 +16,22 @@ const isGroups = data => {
   return !Array.isArray(data)
 }
 
-const getLengthOfSuggestions = data => {
+const getLengthOfSuggestions = (data, maxSuggestions) => {
   if (isGroups(data)) {
     let length = 0
     for (const key in data) {
       const { options } = data[key]
-      length += options.length
+
+      const maxOptionsLength = maxSuggestions
+        ? Math.min(maxSuggestions, options.length)
+        : options.length
+
+      length += maxOptionsLength
     }
 
     return length
   } else {
-    return data.length
+    return maxSuggestions ? Math.min(maxSuggestions, data.length) : data.length
   }
 }
 
@@ -192,6 +197,7 @@ class SearchWithSuggestions extends PureComponent {
 
   onKeyDown = evt => {
     const { suggestions, cursor } = this.state
+    const { maxSuggestions } = this.props
     const { key, currentTarget } = evt
     let newCursor = cursor
 
@@ -212,7 +218,7 @@ class SearchWithSuggestions extends PureComponent {
         return
     }
 
-    const maxCursor = getLengthOfSuggestions(suggestions)
+    const maxCursor = getLengthOfSuggestions(suggestions, maxSuggestions)
     newCursor = newCursor % maxCursor
     this.setState({ cursor: newCursor < 0 ? maxCursor - 1 : newCursor })
   }
@@ -286,7 +292,7 @@ const SuggestionItems = ({
     maxSuggestions ? data.slice(0, maxSuggestions) : data
 
   if (isGroups(suggestions)) {
-    const noData = getLengthOfSuggestions(suggestions) === 0
+    const noData = getLengthOfSuggestions(suggestions, maxSuggestions) === 0
     const types = Object.keys(suggestions)
 
     let fromCounter = 0

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
@@ -68,7 +68,8 @@ class SearchWithSuggestions extends PureComponent {
     className: PropTypes.string,
     classes: PropTypes.object,
     maxSuggestions: PropTypes.number,
-    onViewAllResults: PropTypes.func
+    onViewAllResults: PropTypes.func,
+    openOnFocus: PropTypes.bool
   }
 
   static defaultProps = {
@@ -83,7 +84,8 @@ class SearchWithSuggestions extends PureComponent {
     value: '',
     defaultValue: '',
     className: '',
-    classes: {}
+    classes: {},
+    openOnFocus: false
   }
 
   static getDerivedStateFromProps ({ value, data }, state) {
@@ -104,7 +106,8 @@ class SearchWithSuggestions extends PureComponent {
     lastValue: this.props.value,
     isFocused: false,
     cursor: 0,
-    isSearching: false
+    isSearching: false,
+    onViewAllResults: this.props.onViewAllResults
   }
 
   componentWillUnmount () {
@@ -230,7 +233,8 @@ class SearchWithSuggestions extends PureComponent {
       searchTerm,
       isFocused,
       isSearching,
-      cursor
+      cursor,
+      onViewAllResults
     } = this.state
     const {
       suggestionContent,
@@ -239,12 +243,11 @@ class SearchWithSuggestions extends PureComponent {
       suggestionsProps = {},
       className,
       classes = {},
-      data,
       maxSuggestions,
-      onViewAllResults
+      openOnFocus
     } = this.props
 
-    const isByGroups = isGroups(data)
+    console.log(openOnFocus)
 
     return (
       <div className={`${styles.wrapper} ${className}`}>
@@ -257,7 +260,7 @@ class SearchWithSuggestions extends PureComponent {
           onKeyDown={this.onKeyDown}
           {...inputProps}
         />
-        {isFocused && (isByGroups || searchTerm !== '') && (
+        {isFocused && (openOnFocus || searchTerm !== '') && (
           <Panel
             variant='modal'
             className={cx(
@@ -349,13 +352,11 @@ const SuggestionItems = ({
     const sliced = getSliced(suggestions)
     return sliced.length > 0 ? (
       <>
-        {onViewAllResults && (
-          <ViewAllResults
-            searchTerm={searchTerm}
-            onViewAllResults={onViewAllResults}
-            suggestions={suggestions}
-          />
-        )}
+        <ViewAllResults
+          searchTerm={searchTerm}
+          onViewAllResults={onViewAllResults}
+          suggestions={suggestions}
+        />
         <SuggestionItemsList
           suggestions={sliced}
           cursor={cursor}
@@ -378,7 +379,9 @@ const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
     <>
       <div
         className={styles.viewAllResults}
-        onClick={() => onViewAllResults(searchTerm, suggestions)}
+        onMouseDown={() => {
+          onViewAllResults(searchTerm, suggestions)
+        }}
       >
         View all results for “{searchTerm}”
       </div>

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
@@ -67,7 +67,8 @@ class SearchWithSuggestions extends PureComponent {
     dontResetStateAfterSelection: PropTypes.bool,
     className: PropTypes.string,
     classes: PropTypes.object,
-    maxSuggestions: PropTypes.number
+    maxSuggestions: PropTypes.number,
+    onViewAllResults: PropTypes.func
   }
 
   static defaultProps = {
@@ -239,7 +240,8 @@ class SearchWithSuggestions extends PureComponent {
       className,
       classes = {},
       data,
-      maxSuggestions
+      maxSuggestions,
+      onViewAllResults
     } = this.props
 
     const isByGroups = isGroups(data)
@@ -266,6 +268,8 @@ class SearchWithSuggestions extends PureComponent {
             {...suggestionsProps}
           >
             <SuggestionItems
+              searchTerm={searchTerm}
+              onViewAllResults={onViewAllResults}
               suggestions={suggestions}
               cursor={cursor}
               onSuggestionSelect={this.onSuggestionSelect}
@@ -286,7 +290,9 @@ const SuggestionItems = ({
   onSuggestionSelect,
   suggestionContent,
   isSearching,
-  maxSuggestions
+  maxSuggestions,
+  onViewAllResults,
+  searchTerm
 }) => {
   const getSliced = data =>
     maxSuggestions ? data.slice(0, maxSuggestions) : data
@@ -299,6 +305,13 @@ const SuggestionItems = ({
 
     return (
       <>
+        {!noData && (
+          <ViewAllResults
+            searchTerm={searchTerm}
+            onViewAllResults={onViewAllResults}
+            suggestions={suggestions}
+          />
+        )}
         {!noData &&
           types.map((key, index) => {
             const { label, options } = suggestions[key]
@@ -335,16 +348,43 @@ const SuggestionItems = ({
   } else {
     const sliced = getSliced(suggestions)
     return sliced.length > 0 ? (
-      <SuggestionItemsList
-        suggestions={sliced}
-        cursor={cursor}
-        onSuggestionSelect={onSuggestionSelect}
-        suggestionContent={suggestionContent}
-      />
+      <>
+        {onViewAllResults && (
+          <ViewAllResults
+            searchTerm={searchTerm}
+            onViewAllResults={onViewAllResults}
+            suggestions={suggestions}
+          />
+        )}
+        <SuggestionItemsList
+          suggestions={sliced}
+          cursor={cursor}
+          onSuggestionSelect={onSuggestionSelect}
+          suggestionContent={suggestionContent}
+        />
+      </>
     ) : (
       <NoResults isSearching={isSearching} />
     )
   }
+}
+
+const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
+  if (!searchTerm || !onViewAllResults) {
+    return null
+  }
+
+  return (
+    <>
+      <div
+        className={styles.viewAllResults}
+        onClick={() => onViewAllResults(searchTerm, suggestions)}
+      >
+        View all results for “{searchTerm}”
+      </div>
+      <div className={styles.divider} />
+    </>
+  )
 }
 
 const NoResults = ({ isSearching }) => (

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
@@ -61,7 +61,8 @@ class SearchWithSuggestions extends PureComponent {
     suggestionsProps: PropTypes.object,
     dontResetStateAfterSelection: PropTypes.bool,
     className: PropTypes.string,
-    classes: PropTypes.object
+    classes: PropTypes.object,
+    maxSuggestions: PropTypes.number
   }
 
   static defaultProps = {
@@ -231,7 +232,8 @@ class SearchWithSuggestions extends PureComponent {
       suggestionsProps = {},
       className,
       classes = {},
-      data
+      data,
+      maxSuggestions
     } = this.props
 
     const isByGroups = isGroups(data)
@@ -263,6 +265,7 @@ class SearchWithSuggestions extends PureComponent {
               onSuggestionSelect={this.onSuggestionSelect}
               suggestionContent={suggestionContent}
               isSearching={isSearching}
+              maxSuggestions={maxSuggestions}
             />
           </Panel>
         )}
@@ -276,14 +279,17 @@ const SuggestionItems = ({
   cursor,
   onSuggestionSelect,
   suggestionContent,
-  isSearching
+  isSearching,
+  maxSuggestions
 }) => {
-  let fromCounter = 0
+  const getSliced = data =>
+    maxSuggestions ? data.slice(0, maxSuggestions) : data
 
   if (isGroups(suggestions)) {
     const noData = getLengthOfSuggestions(suggestions) === 0
-
     const types = Object.keys(suggestions)
+
+    let fromCounter = 0
 
     return (
       <>
@@ -291,18 +297,20 @@ const SuggestionItems = ({
           types.map((key, index) => {
             const { label, options } = suggestions[key]
 
-            if (!options.length) {
+            const formattedOptions = getSliced(options)
+
+            if (!formattedOptions.length) {
               return null
             }
 
-            fromCounter += options.length
+            fromCounter += formattedOptions.length
 
             return (
               <Fragment key={key}>
                 {label && <div className={styles.groupLabel}>{label}</div>}
                 <SuggestionItemsList
-                  fromCounter={fromCounter - options.length}
-                  suggestions={options}
+                  fromCounter={fromCounter - formattedOptions.length}
+                  suggestions={formattedOptions}
                   cursor={cursor}
                   onSuggestionSelect={selected =>
                     onSuggestionSelect([key, selected])
@@ -319,9 +327,10 @@ const SuggestionItems = ({
       </>
     )
   } else {
-    return suggestions.length > 0 ? (
+    const sliced = getSliced(suggestions)
+    return sliced.length > 0 ? (
       <SuggestionItemsList
-        suggestions={suggestions}
+        suggestions={sliced}
         cursor={cursor}
         onSuggestionSelect={onSuggestionSelect}
         suggestionContent={suggestionContent}

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react'
+import React, { Fragment, PureComponent, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import Panel from '../../Panel/Panel'
@@ -182,12 +182,8 @@ class SearchWithSuggestions extends PureComponent {
         return
     }
 
-    // debugger
-
     const maxCursor = getLengthOfSuggestions(suggestions)
-
     newCursor = newCursor % maxCursor
-
     this.setState({ cursor: newCursor < 0 ? maxCursor - 1 : newCursor })
   }
 
@@ -267,7 +263,6 @@ const SuggestionItems = ({
               <div className={styles.groupLabel}>{label}</div>
               <SuggestionItemsList
                 fromCounter={fromCounter - options.length}
-                groupKey={key}
                 suggestions={options}
                 cursor={cursor}
                 onSuggestionSelect={onSuggestionSelect}
@@ -295,7 +290,6 @@ const SuggestionItems = ({
 }
 
 const SuggestionItemsList = ({
-  groupKey,
   suggestions,
   cursor,
   onSuggestionSelect,
@@ -304,18 +298,45 @@ const SuggestionItemsList = ({
 }) => {
   return suggestions.map((suggestion, index) => {
     const isActive = index + fromCounter === cursor
+
     return (
-      <Button
+      <SuggestionItem
         key={index}
-        fluid
-        variant='ghost'
-        className={cx(styles.suggestion, isActive && styles.cursored)}
-        onMouseDown={() => onSuggestionSelect(suggestion, groupKey)}
-      >
-        {suggestionContent(suggestion)}
-      </Button>
+        isActive={isActive}
+        onSuggestionSelect={onSuggestionSelect}
+        suggestionContent={suggestionContent}
+        suggestion={suggestion}
+      />
     )
   })
+}
+
+const SuggestionItem = ({
+  isActive,
+  onSuggestionSelect,
+  suggestionContent,
+  suggestion
+}) => {
+  const myRef = useRef(null)
+
+  useEffect(() => {
+    isActive &&
+      myRef &&
+      myRef.current &&
+      myRef.current.scrollIntoView({ behavior: 'smooth' })
+  }, [isActive, myRef])
+
+  return (
+    <Button
+      fluid
+      forwardedRef={isActive ? myRef : undefined}
+      variant='ghost'
+      className={cx(styles.suggestion, isActive && styles.cursored)}
+      onMouseDown={() => onSuggestionSelect(suggestion)}
+    >
+      {suggestionContent(suggestion)}
+    </Button>
+  )
 }
 
 export default SearchWithSuggestions

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -11,7 +11,7 @@ $border-color-night: #4a4a4a;
   top: 100%;
   width: 100%;
   margin-top: 4px;
-  padding: 8px;
+  padding: 14px 8px;
   z-index: 5;
   overflow: auto;
   max-height: 180px;
@@ -23,6 +23,8 @@ $border-color-night: #4a4a4a;
   height: auto;
   min-height: 32px;
   text-align: left;
+
+  @include text('body-3');
 
   &:hover,
   &:focus {
@@ -54,9 +56,7 @@ $border-color-night: #4a4a4a;
 .groupLabel {
   @include text('caption');
 
-  margin-top: 12px;
-  margin-bottom: 10px;
-  margin-left: 8px;
+  margin: 12px 0 10px 8px;
   display: flex;
   align-items: center;
   color: var(--waterloo);
@@ -66,4 +66,16 @@ $border-color-night: #4a4a4a;
 .divider {
   border-top: 1px solid var(--porcelain);
   margin: 14px -8px 0 -8px;
+}
+
+.viewAllResults {
+  cursor: pointer;
+  margin-left: 8px;
+  color: var(--mirage);
+
+  @include text('body-3');
+
+  &:hover {
+    color: var(--jungle-green);
+  }
 }

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -19,7 +19,7 @@ $border-color-night: #4a4a4a;
 
 .suggestion {
   padding: 6px 8px;
-  color: var(--waterloo);
+  color: var(--mirage);
   height: auto;
   min-height: 32px;
   text-align: left;
@@ -31,7 +31,7 @@ $border-color-night: #4a4a4a;
 }
 
 .cursored {
-  background: var(--porcelain);
+  background: var(--athens);
 }
 
 .noresults {
@@ -54,15 +54,16 @@ $border-color-night: #4a4a4a;
 .groupLabel {
   @include text('caption');
 
-  margin-bottom: 16px;
+  margin-top: 12px;
+  margin-bottom: 10px;
   margin-left: 8px;
   display: flex;
   align-items: center;
   color: var(--waterloo);
+  font-weight: 600;
 }
 
 .divider {
-  width: 100%;
   border-top: 1px solid var(--porcelain);
-  margin: 14px -8px 12px -8px;
+  margin: 14px -8px 0 -8px;
 }

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -14,7 +14,7 @@ $border-color-night: #4a4a4a;
   padding: 8px;
   z-index: 5;
   overflow: auto;
-  max-height: 175px;
+  max-height: 180px;
 }
 
 .suggestion {

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -17,50 +17,8 @@ $border-color-night: #4a4a4a;
   max-height: 180px;
 }
 
-.suggestion {
-  padding: 6px 8px;
-  color: var(--mirage);
-  height: auto;
-  min-height: 32px;
-  text-align: left;
-
-  @include text('body-3');
-
-  &:hover,
-  &:focus {
-    color: var(--jungle-green);
-  }
-}
-
-.cursored {
-  background: var(--athens);
-}
-
-.noresults {
-  @include text-normal;
-
-  cursor: initial;
-  min-height: auto;
-  text-align: center;
-
-  &:hover,
-  &:focus {
-    background-color: inherit !important;
-  }
-}
-
 .groupSuggestions {
   max-height: 420px;
-}
-
-.groupLabel {
-  @include text('caption');
-
-  margin: 0 0 10px 8px;
-  display: flex;
-  align-items: center;
-  color: var(--waterloo);
-  font-weight: 600;
 }
 
 .divider {

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -11,7 +11,6 @@ $border-color-night: #4a4a4a;
   top: 100%;
   width: 100%;
   margin-top: 4px;
-  padding: 8px;
   z-index: 5;
   overflow: auto;
   max-height: 180px;
@@ -22,13 +21,14 @@ $border-color-night: #4a4a4a;
 }
 
 .divider {
-  border-top: 1px solid var(--porcelain);
-  margin: 14px -8px 12px -8px;
+  border-bottom: 1px solid var(--porcelain);
+  margin-bottom: 14px;
 }
 
 .viewAllResults {
   cursor: pointer;
-  margin: 6px 8px 14px 8px;
+  margin: 0 -8px 14px -8px;
+  padding: 14px 0 14px 24px;
   color: var(--mirage);
 
   @include text('body-3');

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -11,7 +11,7 @@ $border-color-night: #4a4a4a;
   top: 100%;
   width: 100%;
   margin-top: 4px;
-  padding: 14px 8px;
+  padding: 8px;
   z-index: 5;
   overflow: auto;
   max-height: 180px;
@@ -56,7 +56,7 @@ $border-color-night: #4a4a4a;
 .groupLabel {
   @include text('caption');
 
-  margin: 12px 0 10px 8px;
+  margin: 0 0 10px 8px;
   display: flex;
   align-items: center;
   color: var(--waterloo);
@@ -65,12 +65,12 @@ $border-color-night: #4a4a4a;
 
 .divider {
   border-top: 1px solid var(--porcelain);
-  margin: 14px -8px 0 -8px;
+  margin: 14px -8px 12px -8px;
 }
 
 .viewAllResults {
   cursor: pointer;
-  margin-left: 8px;
+  margin: 6px 8px 14px 8px;
   color: var(--mirage);
 
   @include text('body-3');

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.module.scss
@@ -13,6 +13,8 @@ $border-color-night: #4a4a4a;
   margin-top: 4px;
   padding: 8px;
   z-index: 5;
+  overflow: auto;
+  max-height: 175px;
 }
 
 .suggestion {
@@ -43,4 +45,24 @@ $border-color-night: #4a4a4a;
   &:focus {
     background-color: inherit !important;
   }
+}
+
+.groupSuggestions {
+  max-height: 420px;
+}
+
+.groupLabel {
+  @include text('caption');
+
+  margin-bottom: 16px;
+  margin-left: 8px;
+  display: flex;
+  align-items: center;
+  color: var(--waterloo);
+}
+
+.divider {
+  width: 100%;
+  border-top: 1px solid var(--porcelain);
+  margin: 14px -8px 12px -8px;
 }

--- a/src/Search/SearchWithSuggestions/SearchWithSuggestions.spec.js
+++ b/src/Search/SearchWithSuggestions/SearchWithSuggestions.spec.js
@@ -19,7 +19,6 @@ describe('SearchWithSuggestions', () => {
         suggestionContent={suggestion => suggestion}
         predicate={searchTerm => item =>
           item.toUpperCase().includes(searchTerm.toUpperCase())}
-        maxSuggestions={5}
       />
     )
     expect(shallowToJson(output)).toMatchSnapshot()
@@ -40,7 +39,6 @@ describe('SearchWithSuggestions', () => {
         suggestionContent={suggestion => suggestion}
         predicate={searchTerm => item =>
           item.toUpperCase().includes(searchTerm.toUpperCase())}
-        maxSuggestions={5}
       />
     )
     const searchInput = output.find('Input')

--- a/src/Search/SearchWithSuggestions/SuggestionItem.js
+++ b/src/Search/SearchWithSuggestions/SuggestionItem.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef } from 'react'
+import cx from 'classnames'
+import Button from '../../Button'
+import styles from './SuggestionItem.module.scss'
+
+const SuggestionItem = ({
+  isActive,
+  onSuggestionSelect,
+  suggestionContent,
+  suggestion
+}) => {
+  const myRef = useRef(null)
+
+  useEffect(() => {
+    isActive && myRef && myRef.current && myRef.current.scrollIntoView(false)
+  }, [isActive, myRef])
+
+  return (
+    <Button
+      fluid
+      forwardedRef={isActive ? myRef : undefined}
+      variant='ghost'
+      className={cx(styles.suggestion, isActive && styles.cursored)}
+      onMouseDown={() => onSuggestionSelect(suggestion)}
+    >
+      {suggestionContent(suggestion)}
+    </Button>
+  )
+}
+
+export default SuggestionItem

--- a/src/Search/SearchWithSuggestions/SuggestionItem.module.scss
+++ b/src/Search/SearchWithSuggestions/SuggestionItem.module.scss
@@ -1,0 +1,20 @@
+@import '../../mixins';
+
+.suggestion {
+  padding: 6px 8px;
+  color: var(--mirage);
+  height: auto;
+  min-height: 32px;
+  text-align: left;
+
+  @include text('body-3');
+
+  &:hover,
+  &:focus {
+    color: var(--jungle-green);
+  }
+}
+
+.cursored {
+  background: var(--athens);
+}

--- a/src/Search/SearchWithSuggestions/SuggestionItems.js
+++ b/src/Search/SearchWithSuggestions/SuggestionItems.js
@@ -1,0 +1,94 @@
+import React, { Fragment } from 'react'
+import SuggestionItemsList from './SuggestionsItemsList'
+import ViewAllResults from './ViewAllResults'
+import { getLengthOfSuggestions, isGroups } from './SearchWithSuggestions'
+import NoResults from './NoResults'
+import commonStyles from './SearchWithSuggestions.module.scss'
+import styles from './SuggestionItems.module.scss'
+
+const SuggestionItems = ({
+  suggestions,
+  cursor,
+  onSuggestionSelect,
+  suggestionContent,
+  isSearching,
+  maxSuggestions,
+  onViewAllResults,
+  searchTerm
+}) => {
+  const getSliced = data =>
+    maxSuggestions ? data.slice(0, maxSuggestions) : data
+
+  if (isGroups(suggestions)) {
+    const noData = getLengthOfSuggestions(suggestions, maxSuggestions) === 0
+    const types = Object.keys(suggestions)
+
+    let fromCounter = 0
+
+    return (
+      <>
+        {noData ? (
+          <NoResults isSearching={isSearching} />
+        ) : (
+          <>
+            <ViewAllResults
+              searchTerm={searchTerm}
+              onViewAllResults={onViewAllResults}
+              suggestions={suggestions}
+            />
+            {types.map((key, index) => {
+              const { label, options } = suggestions[key]
+
+              const formattedOptions = getSliced(options)
+
+              if (!formattedOptions.length) {
+                return null
+              }
+
+              fromCounter += formattedOptions.length
+
+              return (
+                <Fragment key={key}>
+                  {label && <div className={styles.groupLabel}>{label}</div>}
+                  <SuggestionItemsList
+                    fromCounter={fromCounter - formattedOptions.length}
+                    suggestions={formattedOptions}
+                    cursor={cursor}
+                    onSuggestionSelect={selected =>
+                      onSuggestionSelect([key, selected])
+                    }
+                    suggestionContent={suggestionContent}
+                  />
+                  {index !== types.length - 1 && (
+                    <div className={commonStyles.divider} />
+                  )}
+                </Fragment>
+              )
+            })}
+          </>
+        )}
+      </>
+    )
+  } else {
+    const sliced = getSliced(suggestions)
+    return sliced.length > 0 ? (
+      <>
+        <ViewAllResults
+          searchTerm={searchTerm}
+          onViewAllResults={onViewAllResults}
+          suggestions={suggestions}
+        />
+        <SuggestionItemsList
+          suggestions={sliced}
+          cursor={cursor}
+          onSuggestionSelect={onSuggestionSelect}
+          suggestionContent={suggestionContent}
+        />
+      </>
+    ) : (
+      <NoResults isSearching={isSearching} />
+    )
+  }
+}
+
+export default SuggestionItems

--- a/src/Search/SearchWithSuggestions/SuggestionItems.js
+++ b/src/Search/SearchWithSuggestions/SuggestionItems.js
@@ -48,7 +48,14 @@ const SuggestionItems = ({
               fromCounter += formattedOptions.length
 
               return (
-                <Fragment key={key}>
+                <div
+                  key={key}
+                  className={
+                    index !== types.length - 1
+                      ? commonStyles.divider
+                      : undefined
+                  }
+                >
                   {label && <div className={styles.groupLabel}>{label}</div>}
                   <SuggestionItemsList
                     fromCounter={fromCounter - formattedOptions.length}
@@ -59,10 +66,7 @@ const SuggestionItems = ({
                     }
                     suggestionContent={suggestionContent}
                   />
-                  {index !== types.length - 1 && (
-                    <div className={commonStyles.divider} />
-                  )}
-                </Fragment>
+                </div>
               )
             })}
           </>

--- a/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
+++ b/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
@@ -3,7 +3,7 @@
 .groupLabel {
   @include text('caption');
 
-  margin: 0 0 2px 16px;
+  margin: 10px 0 2px 16px;
   display: flex;
   align-items: center;
   color: var(--waterloo);

--- a/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
+++ b/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
@@ -1,0 +1,11 @@
+@import '../../mixins';
+
+.groupLabel {
+  @include text('caption');
+
+  margin: 0 0 10px 8px;
+  display: flex;
+  align-items: center;
+  color: var(--waterloo);
+  font-weight: 600;
+}

--- a/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
+++ b/src/Search/SearchWithSuggestions/SuggestionItems.module.scss
@@ -3,7 +3,7 @@
 .groupLabel {
   @include text('caption');
 
-  margin: 0 0 10px 8px;
+  margin: 0 0 2px 16px;
   display: flex;
   align-items: center;
   color: var(--waterloo);

--- a/src/Search/SearchWithSuggestions/SuggestionItemsList.module.scss
+++ b/src/Search/SearchWithSuggestions/SuggestionItemsList.module.scss
@@ -1,0 +1,3 @@
+.list {
+  padding: 8px;
+}

--- a/src/Search/SearchWithSuggestions/SuggestionsItemsList.js
+++ b/src/Search/SearchWithSuggestions/SuggestionsItemsList.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import SuggestionItem from './SuggestionItem'
+import styles from './SuggestionItemsList.module.scss'
 
 export const SuggestionItemsList = ({
   suggestions,
@@ -8,18 +9,22 @@ export const SuggestionItemsList = ({
   suggestionContent,
   fromCounter = 0
 }) => {
-  return suggestions.map((suggestion, index) => {
-    const isActive = index + fromCounter === cursor
-    return (
-      <SuggestionItem
-        key={index}
-        isActive={isActive}
-        onSuggestionSelect={onSuggestionSelect}
-        suggestionContent={suggestionContent}
-        suggestion={suggestion}
-      />
-    )
-  })
+  return (
+    <div className={styles.list}>
+      {suggestions.map((suggestion, index) => {
+        const isActive = index + fromCounter === cursor
+        return (
+          <SuggestionItem
+            key={index}
+            isActive={isActive}
+            onSuggestionSelect={onSuggestionSelect}
+            suggestionContent={suggestionContent}
+            suggestion={suggestion}
+          />
+        )
+      })}
+    </div>
+  )
 }
 
 export default SuggestionItemsList

--- a/src/Search/SearchWithSuggestions/SuggestionsItemsList.js
+++ b/src/Search/SearchWithSuggestions/SuggestionsItemsList.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import SuggestionItem from './SuggestionItem'
+
+export const SuggestionItemsList = ({
+  suggestions,
+  cursor,
+  onSuggestionSelect,
+  suggestionContent,
+  fromCounter = 0
+}) => {
+  return suggestions.map((suggestion, index) => {
+    const isActive = index + fromCounter === cursor
+    return (
+      <SuggestionItem
+        key={index}
+        isActive={isActive}
+        onSuggestionSelect={onSuggestionSelect}
+        suggestionContent={suggestionContent}
+        suggestion={suggestion}
+      />
+    )
+  })
+}
+
+export default SuggestionItemsList

--- a/src/Search/SearchWithSuggestions/ViewAllResults.js
+++ b/src/Search/SearchWithSuggestions/ViewAllResults.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import styles from './SearchWithSuggestions.module.scss'
+
+const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
+  if (!searchTerm || !onViewAllResults) {
+    return null
+  }
+
+  return (
+    <>
+      <div
+        className={styles.viewAllResults}
+        onMouseDown={() => {
+          onViewAllResults(searchTerm, suggestions)
+        }}
+      >
+        View all results for “{searchTerm}”
+      </div>
+      <div className={styles.divider} />
+    </>
+  )
+}
+
+export default ViewAllResults

--- a/src/Search/SearchWithSuggestions/ViewAllResults.js
+++ b/src/Search/SearchWithSuggestions/ViewAllResults.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import styles from './SearchWithSuggestions.module.scss'
 
 const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
@@ -9,14 +10,13 @@ const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
   return (
     <>
       <div
-        className={styles.viewAllResults}
+        className={cx(styles.divider, styles.viewAllResults)}
         onMouseDown={() => {
           onViewAllResults(searchTerm, suggestions)
         }}
       >
         View all results for “{searchTerm}”
       </div>
-      <div className={styles.divider} />
     </>
   )
 }

--- a/src/Search/SearchWithSuggestions/ViewAllResults.js
+++ b/src/Search/SearchWithSuggestions/ViewAllResults.js
@@ -8,16 +8,14 @@ const ViewAllResults = ({ searchTerm, onViewAllResults, suggestions }) => {
   }
 
   return (
-    <>
-      <div
-        className={cx(styles.divider, styles.viewAllResults)}
-        onMouseDown={() => {
-          onViewAllResults(searchTerm, suggestions)
-        }}
-      >
-        View all results for “{searchTerm}”
-      </div>
-    </>
+    <div
+      className={cx(styles.divider, styles.viewAllResults)}
+      onMouseDown={() => {
+        onViewAllResults(searchTerm, suggestions)
+      }}
+    >
+      View all results for “{searchTerm}”
+    </div>
   )
 }
 

--- a/src/Search/SearchWithSuggestions/__snapshots__/SearchWithSuggestions.spec.js.snap
+++ b/src/Search/SearchWithSuggestions/__snapshots__/SearchWithSuggestions.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`SearchWithSuggestions should render Bigbom as a child 1`] = `
 <SearchWithSuggestions
   className=""
+  classes={Object {}}
   data={
     Array [
       "Bibox Token",
@@ -17,7 +18,6 @@ exports[`SearchWithSuggestions should render Bigbom as a child 1`] = `
   defaultValue=""
   dontResetStateAfterSelection={false}
   inputProps={Object {}}
-  maxSuggestions={5}
   onSuggestionSelect={[Function]}
   onSuggestionsUpdate={[Function]}
   predicate={[Function]}

--- a/src/Search/SearchWithSuggestions/__snapshots__/SearchWithSuggestions.spec.js.snap
+++ b/src/Search/SearchWithSuggestions/__snapshots__/SearchWithSuggestions.spec.js.snap
@@ -20,6 +20,7 @@ exports[`SearchWithSuggestions should render Bigbom as a child 1`] = `
   inputProps={Object {}}
   onSuggestionSelect={[Function]}
   onSuggestionsUpdate={[Function]}
+  openOnFocus={false}
   predicate={[Function]}
   sorter={[Function]}
   suggestionContent={[Function]}

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -194,3 +194,54 @@ stories.add(
     }
   }
 )
+
+stories.add('Suggestions by groups', () => (
+  <ColorModeComparison>
+    <SearchWithSuggestions
+      data={{
+        assets: {
+          label: 'Assets',
+          options: [
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin',
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+          ]
+        },
+        words: {
+          label: 'Trending words',
+          options: [
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin',
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+          ]
+        },
+        watchlists: {
+          label: 'Watchlists',
+          options: [
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin',
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+          ]
+        }
+      }}
+      onSuggestionSelect={action('selected')}
+      iconPosition='left'
+      suggestionContent={suggestion => suggestion}
+      predicate={searchTerm => item =>
+        item.toUpperCase().includes(searchTerm.toUpperCase())}
+      maxSuggestions={5}
+    />
+  </ColorModeComparison>
+))

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -226,6 +226,7 @@ stories.add('Suggestions by groups', () => (
         item.toUpperCase().includes(searchTerm.toUpperCase())}
       dontResetStateAfterSelection
       maxSuggestions={5}
+      onViewAllResults={console.log}
     />
   </ColorModeComparison>
 ))

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -7,6 +7,50 @@ import ColorModeComparison from './ColorModeComparison'
 
 const stories = storiesOf('Search', module)
 
+const SUGGESTION_GROUPS = {
+  assets: {
+    label: 'Assets',
+    options: ['Bibox Token', 'Bigbom', 'Binance Coin', 'BioCoin']
+  },
+  words: {
+    label: 'Trending words',
+    options: [
+      'Bibox Token Words',
+      'Bigbom Words',
+      'Binance Coin Words',
+      'BioCoin Words',
+      'BitBay Words',
+      'bitcoin Words',
+      'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj Words',
+      'Bibox Token Words',
+      'Bigbom Words',
+      'Binance Coin Words',
+      'BioCoin Words',
+      'BitBay Words',
+      'bitcoin Words',
+      'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj Words',
+      'Bibox Token Words',
+      'Bigbom Words',
+      'Binance Coin Words',
+      'BioCoin Words',
+      'BitBay Words',
+      'bitcoin Words'
+    ]
+  },
+  watchlists: {
+    label: 'Watchlists',
+    options: [
+      'Bibox Token Watchlist',
+      'Bigbom Watchlist',
+      'Binance Coin Watchlist',
+      'BioCoin Watchlist',
+      'BitBay Watchlist',
+      'bitcoin Watchlist',
+      'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj Watchlist'
+    ]
+  }
+}
+
 class Test extends React.PureComponent {
   state = {
     value: 'Bibox Token'
@@ -32,9 +76,7 @@ class Test extends React.PureComponent {
         suggestionContent={suggestion => suggestion}
         predicate={searchTerm => item =>
           item.toUpperCase().includes(searchTerm.toUpperCase())}
-        maxSuggestions={5}
         dontResetStateAfterSelection
-        value={'000=' + this.state.value}
       />
     )
   }
@@ -68,7 +110,6 @@ stories.add('Suggestions', () => (
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
     />
   </ColorModeComparison>
 ))
@@ -90,7 +131,6 @@ stories.add('Suggestions (Keep state after suggestion)', () => (
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
       dontResetStateAfterSelection
     />
     <br />
@@ -110,7 +150,6 @@ stories.add('Suggestions (Keep state after suggestion)', () => (
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
       dontResetStateAfterSelection
     />
   </ColorModeComparison>
@@ -133,7 +172,6 @@ stories.add('Suggestions (Sorting by length)', () => (
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
       dontResetStateAfterSelection
       sorter={(itemA, itemB) => itemA.length - itemB.length}
     />
@@ -143,6 +181,32 @@ stories.add('Suggestions (Sorting by length)', () => (
 stories.add('Suggestions derived value', () => (
   <ColorModeComparison>
     <Test />
+  </ColorModeComparison>
+))
+
+stories.add('Suggestions by groups', () => (
+  <ColorModeComparison>
+    <SearchWithSuggestions
+      data={SUGGESTION_GROUPS}
+      onSuggestionSelect={action('selected')}
+      iconPosition='left'
+      suggestionContent={suggestion => suggestion}
+      predicate={searchTerm => item =>
+        item.toUpperCase().includes(searchTerm.toUpperCase())}
+    />
+
+    <div>Don't reset state after selection:</div>
+    <SearchWithSuggestions
+      data={SUGGESTION_GROUPS}
+      onSuggestionSelect={suggestion => {
+        action('selected')(suggestion)
+      }}
+      iconPosition='left'
+      suggestionContent={suggestion => suggestion}
+      predicate={searchTerm => item =>
+        item.toUpperCase().includes(searchTerm.toUpperCase())}
+      dontResetStateAfterSelection
+    />
   </ColorModeComparison>
 ))
 
@@ -162,7 +226,6 @@ stories.add(
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
     />
   ),
   {
@@ -173,19 +236,32 @@ stories.add(
     ~~~js
       <SearchWithSuggestions
         iconPosition='none'
-        data={[
-          'Bibox Token',
-          'Bigbom',
-          'Binance Coin',
-          'BioCoin',
-          'BitBay',
-          'bitcoin'
-        ]}
+        data={}
         onSuggestionSelect={suggestion = console.log(suggestion)}
         suggestionContent={suggestion => suggestion}
         predicate={searchTerm => item =>
           item.toUpperCase().includes(searchTerm.toUpperCase())}
-          maxSuggestions={5}
+        />
+    ~~~
+    
+    ~~~js
+      <SearchWithSuggestions
+        iconPosition='none'
+        data={{
+            assets: {
+                label: 'Assets',
+                options: ['Bibox Token', 'Bigbom', 'Binance Coin', 'BioCoin']
+            },
+            
+            words: {
+                label: 'Words',
+                options: ['Bibox Token', 'Bigbom', 'Binance Coin', 'BioCoin']
+            },
+        }}
+        onSuggestionSelect={suggestion = console.log(suggestion)}
+        suggestionContent={suggestion => suggestion}
+        predicate={searchTerm => item =>
+          item.toUpperCase().includes(searchTerm.toUpperCase())}
         />
     ~~~
   `,
@@ -194,72 +270,3 @@ stories.add(
     }
   }
 )
-
-stories.add('Suggestions by groups', () => (
-  <ColorModeComparison>
-    <SearchWithSuggestions
-      data={{
-        assets: {
-          label: 'Assets',
-          options: ['Bibox Token', 'Bigbom', 'Binance Coin', 'BioCoin']
-        },
-        words: {
-          label: 'Trending words',
-          options: [
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin'
-          ]
-        },
-        watchlists: {
-          label: 'Watchlists',
-          options: [
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin'
-          ]
-        }
-      }}
-      onSuggestionSelect={action('selected')}
-      iconPosition='left'
-      suggestionContent={suggestion => suggestion}
-      predicate={searchTerm => item =>
-        item.toUpperCase().includes(searchTerm.toUpperCase())}
-      maxSuggestions={5}
-    />
-  </ColorModeComparison>
-))

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -214,7 +214,7 @@ stories.add('Suggestions by groups', () => (
         item.toUpperCase().includes(searchTerm.toUpperCase())}
     />
 
-    <div>Don't reset state after selection:</div>
+    <div>Don't reset state after selection with maxSuggestions = 5:</div>
     <SearchWithSuggestions
       data={SUGGESTION_GROUPS}
       onSuggestionSelect={suggestion => {
@@ -225,6 +225,7 @@ stories.add('Suggestions by groups', () => (
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
       dontResetStateAfterSelection
+      maxSuggestions={5}
     />
   </ColorModeComparison>
 ))

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -212,6 +212,7 @@ stories.add('Suggestions by groups', () => (
       suggestionContent={suggestion => suggestion}
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
+      openOnFocus
     />
 
     <div>Don't reset state after selection with maxSuggestions = 5:</div>
@@ -227,6 +228,7 @@ stories.add('Suggestions by groups', () => (
       dontResetStateAfterSelection
       maxSuggestions={5}
       onViewAllResults={console.log}
+      openOnFocus
     />
   </ColorModeComparison>
 ))

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -201,15 +201,7 @@ stories.add('Suggestions by groups', () => (
       data={{
         assets: {
           label: 'Assets',
-          options: [
-            'Bibox Token',
-            'Bigbom',
-            'Binance Coin',
-            'BioCoin',
-            'BitBay',
-            'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
-          ]
+          options: ['Bibox Token', 'Bigbom', 'Binance Coin', 'BioCoin']
         },
         words: {
           label: 'Trending words',
@@ -220,7 +212,20 @@ stories.add('Suggestions by groups', () => (
             'BioCoin',
             'BitBay',
             'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin',
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin'
           ]
         },
         watchlists: {
@@ -232,7 +237,20 @@ stories.add('Suggestions by groups', () => (
             'BioCoin',
             'BitBay',
             'bitcoin',
-            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin',
+            'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj',
+            'Bibox Token',
+            'Bigbom',
+            'Binance Coin',
+            'BioCoin',
+            'BitBay',
+            'bitcoin'
           ]
         }
       }}

--- a/stories/SearchStory.js
+++ b/stories/SearchStory.js
@@ -111,6 +111,25 @@ stories.add('Suggestions', () => (
       predicate={searchTerm => item =>
         item.toUpperCase().includes(searchTerm.toUpperCase())}
     />
+
+    <div>Max suggestions 5</div>
+    <SearchWithSuggestions
+      data={[
+        'Bibox Token',
+        'Bigbom',
+        'Binance Coin',
+        'BioCoin',
+        'BitBay',
+        'bitcoin',
+        'Very large title asdbgjhasb jkgdsbfkgjsdbfg gdfj'
+      ]}
+      onSuggestionSelect={action('selected')}
+      iconPosition='left'
+      suggestionContent={suggestion => suggestion}
+      predicate={searchTerm => item =>
+        item.toUpperCase().includes(searchTerm.toUpperCase())}
+      maxSuggestions={5}
+    />
   </ColorModeComparison>
 ))
 


### PR DESCRIPTION
**Summary**

1. Add groups with list of options for suggestion select(for support search via recently searched Assets/Watchlist/TrendingWords/Signals and etc).
2. Open list on focus by optional prop
3. Make maxSuggestion prop as optional

**Screenshots**
Figma: 
![image](https://user-images.githubusercontent.com/14061779/66465829-49706580-ea8a-11e9-9c18-d8990d59726a.png)

Now:
- with option 'View all results'
![image](https://user-images.githubusercontent.com/14061779/66480829-22c12780-eaa8-11e9-992e-1211cabe5650.png)
- without 'View all results'
![image](https://user-images.githubusercontent.com/14061779/66481292-3faa2a80-eaa9-11e9-896b-3997a328dec4.png)
![image](https://user-images.githubusercontent.com/14061779/66465922-74f35000-ea8a-11e9-8d53-74a8c0e26bb5.png)
![image](https://user-images.githubusercontent.com/14061779/66465944-7fade500-ea8a-11e9-8fc4-53146c1b00ed.png)

