### PR TITLE
add offsetX/Y calculations for tooltip

### DIFF
--- a/src/Tooltip/TooltipContent.js
+++ b/src/Tooltip/TooltipContent.js
@@ -51,9 +51,11 @@ class TooltipContent extends PureComponent {
     if (position === 'top' || position === 'bottom') {
       top +=
         (position === 'top' ? -tooltipHeight : triggerHeight) + sign * offsetY
-      left += calculateAlignment(triggerWidth, tooltipWidth, align)
+      left +=
+        calculateAlignment(triggerWidth, tooltipWidth, align) + sign * offsetX
     } else {
-      top += calculateAlignment(triggerHeight, tooltipHeight, align)
+      top +=
+        calculateAlignment(triggerHeight, tooltipHeight, align) + sign * offsetY
       left +=
         (position === 'left' ? -tooltipWidth : triggerWidth) + sign * offsetX
     }

--- a/stories/TooltipStory.js
+++ b/stories/TooltipStory.js
@@ -184,3 +184,15 @@ In order for \`Tooltip\` to work, component hierarchy should look like this:
       test afisudhfoaidsufh content
     </Example>
   ))
+  .add('Tooltip with offsetX = 100 and offsetY = 100', () => (
+    <Example
+      shown
+      position='bottom'
+      align='start'
+      offsetX={100}
+      offsetY={100}
+      trigger={<Icon type='cloud-big' />}
+    >
+      test afisudhfoaidsufh content
+    </Example>
+  ))


### PR DESCRIPTION
**Summary**

Add X-Y offset calculations for tooltips. Before: calculation depended from 'position' value.

**Screenshots**
 
![image](https://user-images.githubusercontent.com/14061779/68858939-3db23780-06f7-11ea-8854-62f8e87578ed.png)

