### PR TITLE
fix/bold-typography

### DIFF
--- a/src/mixins.scss
+++ b/src/mixins.scss
@@ -95,7 +95,7 @@
     line-height: 66px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -104,7 +104,7 @@
     line-height: 44px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -113,7 +113,7 @@
     line-height: 40px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -122,7 +122,7 @@
     line-height: 30px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -137,7 +137,7 @@
       line-height: 26px;
 
       @if $mod == 'm' {
-        font-weight: bold;
+        font-weight: 500;
       }
     }
   }
@@ -147,7 +147,7 @@
     line-height: 24px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -156,7 +156,7 @@
     line-height: 20px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 
@@ -165,7 +165,7 @@
     line-height: 18px;
 
     @if $mod == 'm' {
-      font-weight: bold;
+      font-weight: 500;
     }
   }
 }


### PR DESCRIPTION
**Summary**
Currently in `app` we fetch only `Rubik Regular` font and make it bold as `font-weight: bold`.
Here 2 mistakes:
- `Rubik` has a special `bold` subfont with some changes between and in symbols
- In our library we should use `Rubik Medium` font and `font-weight: 500` (instead `font-weight: bold` = 700)

Difference: 
![image](https://user-images.githubusercontent.com/24521041/73173747-23dd9980-4117-11ea-82b0-a22ac73b79ac.png)
 