### PR TITLE
fix/button/as-props

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -46,7 +46,11 @@ const Button = ({
 }
 
 Button.propTypes = {
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  as: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.element
+  ]),
   fluid: PropTypes.bool,
   isActive: PropTypes.bool,
   isLoading: PropTypes.bool,

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -49,7 +49,8 @@ Button.propTypes = {
   as: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
-    PropTypes.element
+    PropTypes.element,
+    PropTypes.elementType
   ]),
   fluid: PropTypes.bool,
   isActive: PropTypes.bool,


### PR DESCRIPTION
**Summary**
- Alllow React Elements as `as` prop